### PR TITLE
Heroku用のデプロイ設定

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-apache2 public/

--- a/app/Http/Controllers/ResetTablesController.php
+++ b/app/Http/Controllers/ResetTablesController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * sampleアプリケーションなので定期的にデータを削除したいがherokuだとschedulerに制限があるので
+ * 外部から削除できるようにする
+ *
+ */
+class ResetTablesController extends Controller
+{
+    public function clear(Request $request)
+    {
+        if (App::environment('heroku')) {
+            return response()->json(['result' => false, 'message' => 'failed environment'], 403);
+        }
+        if ($request->key !== config('app.key')) {
+            return response()->json(['result' => false, 'message' => 'missing key'], 403);
+        }
+        Artisan::call('migrate:fresh --seed');
+        return response()->json(['result' => true, 'message' => 'success delete'], 200);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\Post;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -25,6 +26,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if (App::isProduction()) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Models\Post;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -26,7 +27,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (App::isProduction()) {
+        if (App::environment(['heroku', 'production'])) {
             URL::forceScheme('https');
         }
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        $this->call(SamplePostSeeder::class);
     }
 }

--- a/database/seeders/SamplePostSeeder.php
+++ b/database/seeders/SamplePostSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class SamplePostSeeder extends Seeder
+{
+    const DIR = 'markdown/test/*';
+
+    /**
+     * Set Example Post
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $admin = User::factory()->create(['name' => 'admin', 'email' => 'test@example.com', 'password' => encrypt('example1234')]);
+        $markdown_dir = resource_path(self::DIR);
+        $files = glob($markdown_dir);
+        collect($files)->each(function ($file) use ($admin) {
+            $filename = Str::of($file)->basename('.md');
+            Post::create([
+                'user_id' => $admin->id,
+                'title' => $filename,
+                'content' => File::get($file),
+                'published' => true
+            ]);
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "watch-poll": "mix watch -- --watch-options-poll=1000",
         "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "mix --production"
+        "production": "mix --production",
+        "heroku-postbuild": "npm run prod"
     },
     "devDependencies": {
         "@inertiajs/inertia": "^0.8.2",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,4 +18,10 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =http [OR]
+    RewriteCond %{HTTP:X-Forwarded-Proto} =""
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
 </IfModule>

--- a/resources/markdown/policy.md
+++ b/resources/markdown/policy.md
@@ -1,3 +1,0 @@
-# Privacy Policy
-
-Edit this file to define the privacy policy for your application.

--- a/resources/markdown/terms.md
+++ b/resources/markdown/terms.md
@@ -1,3 +1,0 @@
-# Terms of Service
-
-Edit this file to define the terms of service for your application.

--- a/resources/markdown/test/readme.md
+++ b/resources/markdown/test/readme.md
@@ -1,0 +1,31 @@
+## About
+
+Inertia.jsによって構築された、LaravelとVueによるシンプルなモノリスSPAブログ。
+
+JetStreamでの認証を管理画面として使用し、投稿の基本的なCRUDを作成。  
+記事の作成ではmarkdownを使用できる。
+
+### About Inertia
+
+Inertia.jsを使用すると、従来のサーバー側ルーティングとコントローラーを使用して、最新の単一ページのReact、Vue、およびSvelteアプリをすばやく構築できます。  
+[more](https://inertiajs.com/)
+
+
+## Feature
+
+記事一覧
+![index](https://user-images.githubusercontent.com/40763821/140657304-c328c437-fd08-4f0e-b62a-ff5147149be3.png)
+
+記事詳細
+![show](https://user-images.githubusercontent.com/40763821/140657317-91a98f3d-1d8c-458b-855f-d0443dc592ae.png)
+
+管理画面-記事一覧
+![スクリーンショット 2021-11-07 23 56 37](https://user-images.githubusercontent.com/40763821/140657306-04db8bfb-d972-4342-b27b-83444dfc09df.png)
+管理画面-記事作成/編集
+![スクリーンショット 2021-11-07 23 56 56](https://user-images.githubusercontent.com/40763821/140657308-b4bb3d9c-1d29-49af-adf5-79efb007ced1.png)
+管理画面-記事削除
+![スクリーンショット 2021-11-07 23 57 14](https://user-images.githubusercontent.com/40763821/140657312-69a74005-ad38-4fc2-a724-75cf9d16de4e.png)
+![スクリーンショット 2021-11-07 23 58 49](https://user-images.githubusercontent.com/40763821/140657316-d3afff9f-01f4-495e-8ae2-f7c48b40fd92.png)
+
+## License
+[MIT license](https://opensource.org/licenses/MIT).

--- a/resources/markdown/test/test.md
+++ b/resources/markdown/test/test.md
@@ -1,0 +1,3 @@
+# hello
+
+this is test post.

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('cleartables', [\App\Http\Controllers\ResetTablesController::class, 'clear']);


### PR DESCRIPTION
# 概要
Herokuのデプロイで必要なファイルの追加と、デフォルトのユーザを作成し、ダミー記事を作成しておく

# 詳細

1. Herokuにサンプルとしてデプロイするので設定の追加
2. だれでもユーザーを作成し登録できるので外部からDBのmigrateをできるように
